### PR TITLE
BitArray.h: Fix memory under-allocation

### DIFF
--- a/cpp/include/psu-ds/BitArray.h
+++ b/cpp/include/psu-ds/BitArray.h
@@ -30,7 +30,7 @@ namespace psudb {
         explicit BitArray(size_t bits) : m_bits(bits), m_data(nullptr) {
             if (m_bits > 0) {
                 size_t n_bytes = m_bits >> 3;
-                n_bytes += n_bytes == 0; // account for 0 bytes
+                if (n_bytes % CACHELINE_SIZE == 0 && (m_bits & 0x7) != 0) n_bytes++;
 
                 m_memory_usage = sf_aligned_alloc(CACHELINE_SIZE, n_bytes, &m_data);
                 memset(m_data, 0, m_memory_usage);


### PR DESCRIPTION
When the number of bits required for the bitarray is an exact multiple of the number of bits in a cacheline, insufficient bits are allocated.

This isn't the best possible fix--there's obviously something going wrong under the hood that is leading to this problem, but I'm getting tired of manually making this change every time I clone a copy of my research code, so I'm proposing to push this into the main repo until someone gets a chance to look at it more closely.

This addresses https://github.com/psu-db/psudb-common/issues/4
